### PR TITLE
fix: prioritize env vars over config file for API keys

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,25 @@ Complete reference for `~/.config/spindle/config.toml`. See the [README](../READ
 
 Changes require restarting the daemon (`spindle stop && spindle start`).
 
+## API Keys and Secrets
+
+**Environment variables always override config file values for API keys.** This is a security best practice that allows you to:
+
+- Keep secrets out of config files that might be accidentally shared or committed
+- Use different credentials in development vs production
+- Integrate with secret managers and container orchestration
+
+| Config Key | Environment Variable(s) |
+| --- | --- |
+| `tmdb.api_key` | `TMDB_API_KEY` |
+| `jellyfin.api_key` | `JELLYFIN_API_KEY` |
+| `subtitles.opensubtitles_api_key` | `OPENSUBTITLES_API_KEY` |
+| `subtitles.opensubtitles_user_token` | `OPENSUBTITLES_USER_TOKEN` |
+| `subtitles.whisperx_hf_token` | `HUGGING_FACE_HUB_TOKEN` or `HF_TOKEN` |
+| `preset_decider.api_key` | `PRESET_DECIDER_API_KEY`, `OPENROUTER_API_KEY`, or `DEEPSEEK_API_KEY` |
+
+If an environment variable is set, the config file value is ignored for that key.
+
 ## Core Paths & Storage
 
 | Key | Purpose | Notes |
@@ -123,8 +142,9 @@ alignment artifacts inside each queue item's staging folder for debugging.
   directories or malformed TOML before restarting the daemon.
 - Keep `staging_dir` and `rip_cache_dir` on SSD/NVMe storage; encoding churns on
   these paths heavily.
-- Store TMDB and OpenSubtitles credentials in a password manager; the daemon
-  reads the config in plain text.
+- Prefer setting API keys via environment variables rather than config file.
+  This keeps secrets out of files and works better with containers and secret managers.
+- If you must use config file for keys, ensure `chmod 600 ~/.config/spindle/config.toml`.
 - Back up `~/.config/spindle/` (config + tokens) alongside the queue database in
   `~/.local/share/spindle/` if you move hosts.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,9 +169,9 @@ func TestEnvVarOverridesConfigFileForAPIKeys(t *testing.T) {
 			APIKey string `toml:"api_key"`
 		} `toml:"jellyfin"`
 		Subtitles struct {
-			OpenSubtitlesAPIKey   string `toml:"opensubtitles_api_key"`
+			OpenSubtitlesAPIKey    string `toml:"opensubtitles_api_key"`
 			OpenSubtitlesUserToken string `toml:"opensubtitles_user_token"`
-			WhisperXHuggingFace   string `toml:"whisperx_hf_token"`
+			WhisperXHuggingFace    string `toml:"whisperx_hf_token"`
 		} `toml:"subtitles"`
 		PresetDecider struct {
 			APIKey string `toml:"api_key"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,7 +99,6 @@ func TestLoadDefaultConfigUsesEnvTMDBKeyAndExpandsPaths(t *testing.T) {
 }
 
 func TestLoadCustomPath(t *testing.T) {
-	t.Setenv("TMDB_API_KEY", "from-env")
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "spindle.toml")
 
@@ -154,6 +153,77 @@ func TestLoadCustomPath(t *testing.T) {
 	}
 	if cfg.Workflow.HeartbeatTimeout != 200 {
 		t.Fatalf("expected heartbeat timeout 200, got %d", cfg.Workflow.HeartbeatTimeout)
+	}
+}
+
+func TestEnvVarOverridesConfigFileForAPIKeys(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "spindle.toml")
+
+	// Write config file with API keys
+	type payload struct {
+		TMDB struct {
+			APIKey string `toml:"api_key"`
+		} `toml:"tmdb"`
+		Jellyfin struct {
+			APIKey string `toml:"api_key"`
+		} `toml:"jellyfin"`
+		Subtitles struct {
+			OpenSubtitlesAPIKey   string `toml:"opensubtitles_api_key"`
+			OpenSubtitlesUserToken string `toml:"opensubtitles_user_token"`
+			WhisperXHuggingFace   string `toml:"whisperx_hf_token"`
+		} `toml:"subtitles"`
+		PresetDecider struct {
+			APIKey string `toml:"api_key"`
+		} `toml:"preset_decider"`
+	}
+	custom := payload{}
+	custom.TMDB.APIKey = "file-tmdb"
+	custom.Jellyfin.APIKey = "file-jellyfin"
+	custom.Subtitles.OpenSubtitlesAPIKey = "file-opensub"
+	custom.Subtitles.OpenSubtitlesUserToken = "file-opensub-token"
+	custom.Subtitles.WhisperXHuggingFace = "file-hf"
+	custom.PresetDecider.APIKey = "file-preset"
+
+	data, err := toml.Marshal(custom)
+	if err != nil {
+		t.Fatalf("marshal custom config: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+		t.Fatalf("write custom config: %v", err)
+	}
+
+	// Set env vars that should override
+	t.Setenv("TMDB_API_KEY", "env-tmdb")
+	t.Setenv("JELLYFIN_API_KEY", "env-jellyfin")
+	t.Setenv("OPENSUBTITLES_API_KEY", "env-opensub")
+	t.Setenv("OPENSUBTITLES_USER_TOKEN", "env-opensub-token")
+	t.Setenv("HF_TOKEN", "env-hf")
+	t.Setenv("PRESET_DECIDER_API_KEY", "env-preset")
+
+	cfg, _, _, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	// Verify env vars override config file values
+	if cfg.TMDB.APIKey != "env-tmdb" {
+		t.Errorf("expected TMDB key from env, got %q", cfg.TMDB.APIKey)
+	}
+	if cfg.Jellyfin.APIKey != "env-jellyfin" {
+		t.Errorf("expected Jellyfin key from env, got %q", cfg.Jellyfin.APIKey)
+	}
+	if cfg.Subtitles.OpenSubtitlesAPIKey != "env-opensub" {
+		t.Errorf("expected OpenSubtitles key from env, got %q", cfg.Subtitles.OpenSubtitlesAPIKey)
+	}
+	if cfg.Subtitles.OpenSubtitlesUserToken != "env-opensub-token" {
+		t.Errorf("expected OpenSubtitles token from env, got %q", cfg.Subtitles.OpenSubtitlesUserToken)
+	}
+	if cfg.Subtitles.WhisperXHuggingFace != "env-hf" {
+		t.Errorf("expected HuggingFace token from env, got %q", cfg.Subtitles.WhisperXHuggingFace)
+	}
+	if cfg.PresetDecider.APIKey != "env-preset" {
+		t.Errorf("expected PresetDecider key from env, got %q", cfg.PresetDecider.APIKey)
 	}
 }
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -66,10 +66,9 @@ func (c *Config) normalizePaths() error {
 }
 
 func (c *Config) normalizeTMDB() error {
-	if c.TMDB.APIKey == "" {
-		if value, ok := os.LookupEnv("TMDB_API_KEY"); ok {
-			c.TMDB.APIKey = value
-		}
+	// Environment variables override config file for API keys (security best practice)
+	if value, ok := os.LookupEnv("TMDB_API_KEY"); ok {
+		c.TMDB.APIKey = strings.TrimSpace(value)
 	}
 	c.TMDB.BaseURL = strings.TrimSpace(c.TMDB.BaseURL)
 	if c.TMDB.BaseURL == "" {
@@ -79,13 +78,13 @@ func (c *Config) normalizeTMDB() error {
 }
 
 func (c *Config) normalizeJellyfin() error {
-	if c.Jellyfin.APIKey == "" {
-		if value, ok := os.LookupEnv("JELLYFIN_API_KEY"); ok {
-			c.Jellyfin.APIKey = strings.TrimSpace(value)
-		}
+	// Environment variables override config file for API keys (security best practice)
+	if value, ok := os.LookupEnv("JELLYFIN_API_KEY"); ok {
+		c.Jellyfin.APIKey = strings.TrimSpace(value)
+	} else {
+		c.Jellyfin.APIKey = strings.TrimSpace(c.Jellyfin.APIKey)
 	}
 	c.Jellyfin.URL = strings.TrimSpace(c.Jellyfin.URL)
-	c.Jellyfin.APIKey = strings.TrimSpace(c.Jellyfin.APIKey)
 	return nil
 }
 
@@ -94,29 +93,27 @@ func (c *Config) normalizeSubtitles() error {
 	if c.Subtitles.WhisperXVADMethod == "" {
 		c.Subtitles.WhisperXVADMethod = "silero"
 	}
-	c.Subtitles.WhisperXHuggingFace = strings.TrimSpace(c.Subtitles.WhisperXHuggingFace)
-	if c.Subtitles.WhisperXHuggingFace == "" {
-		if value, ok := os.LookupEnv("HUGGING_FACE_HUB_TOKEN"); ok {
-			c.Subtitles.WhisperXHuggingFace = strings.TrimSpace(value)
-		} else if value, ok := os.LookupEnv("HF_TOKEN"); ok {
-			c.Subtitles.WhisperXHuggingFace = strings.TrimSpace(value)
-		}
+	// Environment variables override config file for API keys/tokens (security best practice)
+	if value, ok := os.LookupEnv("HUGGING_FACE_HUB_TOKEN"); ok {
+		c.Subtitles.WhisperXHuggingFace = strings.TrimSpace(value)
+	} else if value, ok := os.LookupEnv("HF_TOKEN"); ok {
+		c.Subtitles.WhisperXHuggingFace = strings.TrimSpace(value)
+	} else {
+		c.Subtitles.WhisperXHuggingFace = strings.TrimSpace(c.Subtitles.WhisperXHuggingFace)
 	}
-	c.Subtitles.OpenSubtitlesAPIKey = strings.TrimSpace(c.Subtitles.OpenSubtitlesAPIKey)
-	if c.Subtitles.OpenSubtitlesAPIKey == "" {
-		if value, ok := os.LookupEnv("OPENSUBTITLES_API_KEY"); ok {
-			c.Subtitles.OpenSubtitlesAPIKey = strings.TrimSpace(value)
-		}
+	if value, ok := os.LookupEnv("OPENSUBTITLES_API_KEY"); ok {
+		c.Subtitles.OpenSubtitlesAPIKey = strings.TrimSpace(value)
+	} else {
+		c.Subtitles.OpenSubtitlesAPIKey = strings.TrimSpace(c.Subtitles.OpenSubtitlesAPIKey)
 	}
 	c.Subtitles.OpenSubtitlesUserAgent = strings.TrimSpace(c.Subtitles.OpenSubtitlesUserAgent)
 	if c.Subtitles.OpenSubtitlesUserAgent == "" {
 		c.Subtitles.OpenSubtitlesUserAgent = defaultOpenSubtitlesUserAgent
 	}
-	c.Subtitles.OpenSubtitlesUserToken = strings.TrimSpace(c.Subtitles.OpenSubtitlesUserToken)
-	if c.Subtitles.OpenSubtitlesUserToken == "" {
-		if value, ok := os.LookupEnv("OPENSUBTITLES_USER_TOKEN"); ok {
-			c.Subtitles.OpenSubtitlesUserToken = strings.TrimSpace(value)
-		}
+	if value, ok := os.LookupEnv("OPENSUBTITLES_USER_TOKEN"); ok {
+		c.Subtitles.OpenSubtitlesUserToken = strings.TrimSpace(value)
+	} else {
+		c.Subtitles.OpenSubtitlesUserToken = strings.TrimSpace(c.Subtitles.OpenSubtitlesUserToken)
 	}
 	if len(c.Subtitles.OpenSubtitlesLanguages) == 0 {
 		c.Subtitles.OpenSubtitlesLanguages = []string{"en"}
@@ -191,15 +188,15 @@ func (c *Config) normalizePresetDecider() error {
 	if c.PresetDecider.TimeoutSeconds <= 0 {
 		c.PresetDecider.TimeoutSeconds = defaultPresetDeciderTimeoutSeconds
 	}
-	c.PresetDecider.APIKey = strings.TrimSpace(c.PresetDecider.APIKey)
-	if c.PresetDecider.APIKey == "" {
-		if value, ok := os.LookupEnv("PRESET_DECIDER_API_KEY"); ok {
-			c.PresetDecider.APIKey = strings.TrimSpace(value)
-		} else if value, ok := os.LookupEnv("OPENROUTER_API_KEY"); ok {
-			c.PresetDecider.APIKey = strings.TrimSpace(value)
-		} else if value, ok := os.LookupEnv("DEEPSEEK_API_KEY"); ok {
-			c.PresetDecider.APIKey = strings.TrimSpace(value)
-		}
+	// Environment variables override config file for API keys (security best practice)
+	if value, ok := os.LookupEnv("PRESET_DECIDER_API_KEY"); ok {
+		c.PresetDecider.APIKey = strings.TrimSpace(value)
+	} else if value, ok := os.LookupEnv("OPENROUTER_API_KEY"); ok {
+		c.PresetDecider.APIKey = strings.TrimSpace(value)
+	} else if value, ok := os.LookupEnv("DEEPSEEK_API_KEY"); ok {
+		c.PresetDecider.APIKey = strings.TrimSpace(value)
+	} else {
+		c.PresetDecider.APIKey = strings.TrimSpace(c.PresetDecider.APIKey)
 	}
 	return nil
 }


### PR DESCRIPTION
Environment variables now always override config file values for
API keys and secrets. This is a security best practice that:

- Prevents accidental exposure via shared/committed config files
- Supports container orchestration and secret managers
- Allows different credentials in dev vs production

Affected keys: TMDB, Jellyfin, OpenSubtitles, HuggingFace, PresetDecider

https://claude.ai/code/session_0124RX6i9rZAiJtbQeLxTzq1