### PR TITLE
Fix design spec: primary subtitle should not be default track

### DIFF
--- a/docs/DESIGN_STAGES.md
+++ b/docs/DESIGN_STAGES.md
@@ -728,7 +728,7 @@ and moves them alongside the MKV to the library.
 
 When `mux_into_mkv` is true:
 - Use `mkvmerge` to embed SRT subtitle tracks into the MKV container.
-- Primary subtitle marked as default track.
+- Primary subtitle marked as non-default track (prevents auto-play in clients).
 - Forced subtitle marked as forced track.
 - Original encoded file is replaced with muxed version.
 


### PR DESCRIPTION
The code correctly sets --default-track-flag 0:no for embedded subtitles
to prevent auto-play in clients like Findroid. Update the design spec to
match this behavior.

https://claude.ai/code/session_01HqurDqLfTcyreNFvf8JyTw